### PR TITLE
Fix countryCode parameter missing during metadata application

### DIFF
--- a/src/TidalSharp/API.cs
+++ b/src/TidalSharp/API.cs
@@ -91,7 +91,9 @@ public class API
         headers ??= [];
         urlParameters ??= [];
         urlParameters["sessionId"] = _activeUser?.SessionID ?? "";
-        urlParameters["countryCode"] = _activeUser?.CountryCode ?? "";
+        var country = _activeUser?.CountryCode ?? "";
+        if (string.IsNullOrEmpty(country)) country = "US";
+        urlParameters["countryCode"] = country;
         urlParameters["limit"] = _session.ItemLimit.ToString();
 
         if (_activeUser != null)


### PR DESCRIPTION
Resolves #53 by providing a fallback countryCode if the active user's CountryCode is null or empty, preventing API request failures.